### PR TITLE
Add anointment oils directly to table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -118,7 +118,7 @@ a:hover {
   color: #EEE;
 }
 
-.description {
+.anointment .description {
   color: #8787FE;
 }
 
@@ -191,6 +191,21 @@ input {
 
 td.name {
   min-width: 175px;
+}
+
+td.description {
+  min-width: 400px;
+}
+
+td.oils {
+  white-space: nowrap;
+  text-align: center;
+}
+
+td.oils img {
+  width: 50px;
+  height: 50px;
+  margin: 0 0.25rem;
 }
 
 img.icon {

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
       <tr>
         <th scope="col" v-on:click="sortBy('name')" v-html="sortHeader('Name')"></th>
         <th scope="col" v-on:click="sortBy('description')" v-html="sortHeader('Description')"></th>
+        <th scope="col" v-if="type !== 'map'">Oils</th>
       </tr>
     </thead>
     <tbody>
@@ -129,7 +130,11 @@
             <a href="#" @click.prevent="setCombo(anointment.value)">{{ anointment.name }}</a>
           </div>
         </td>
-        <td v-html="formatDescription(anointment)"></td>
+        <td class="description" v-html="formatDescription(anointment)"></td>
+        <td class="oils" v-if="type !== 'map'">
+          <img v-for="oil in getAnointmentCombo(anointment.value)" :src="oil.image"
+            :alt="oil.name" :title="oil.name" data-toggle="tooltip">
+        </td>
       </tr>
     </tbody>
   </table>

--- a/index.html
+++ b/index.html
@@ -127,13 +127,12 @@
         <td class="name">
           <div class="d-flex align-items-center h-100">
             <img v-if="type !== 'amulet'" :src="anointment.image" class="icon mr-2">
-            <a href="#" @click.prevent="setCombo(anointment.value)">{{ anointment.name }}</a>
+            <a href="#" @click.prevent="setCombo(anointment)">{{ anointment.name }}</a>
           </div>
         </td>
         <td class="description" v-html="formatDescription(anointment)"></td>
         <td class="oils" v-if="type !== 'map'">
-          <img v-for="oil in getAnointmentCombo(anointment.value)" :src="oil.image"
-            :alt="oil.name" :title="oil.name" data-toggle="tooltip">
+          <img v-for="oil in anointment.combo" :src="oil.image" :alt="oil.name" :title="oil.name" data-toggle="tooltip">
         </td>
       </tr>
     </tbody>

--- a/js/app.js
+++ b/js/app.js
@@ -44,6 +44,12 @@ const app = new Vue({
         })
 
         self[type] = data
+
+        if (type === 'passives') {
+          Vue.nextTick(function() {
+            $('td.oils img').tooltip()
+          })
+        }
       })
     })
 
@@ -94,6 +100,12 @@ const app = new Vue({
       this.search = ''
       this.combo = this.combo.slice(0, this.maxOils)
       $('.table-data').scrollTop(0)
+
+      // Create tooltips for newly rendered oil combo images
+      Vue.nextTick(function() {
+        $('td.oils img').tooltip('dispose')
+        $('td.oils img').tooltip()
+      })
     },
     reset: function() {
       this.search = ''

--- a/js/app.js
+++ b/js/app.js
@@ -146,7 +146,7 @@ Vue.component('anointments-table', {
   },
   template: '#anointments-table',
   methods: {
-    setCombo: function(value) {
+    getAnointmentCombo: function(value) {
       value = parseInt(value)
 
       if (this.type === 'map') {
@@ -154,7 +154,7 @@ Vue.component('anointments-table', {
           return oil.value === value
         })
 
-        this.$parent.addOil(oil)
+        return [oil]
       } else {
         var combo = []
         const maxOils = this.$parent.maxOils
@@ -171,7 +171,20 @@ Vue.component('anointments-table', {
           value -= oil.value
         }
 
-        this.$parent.combo = combo
+        return combo
+      }
+    },
+    setCombo: function(value) {
+      value = parseInt(value)
+
+      if (this.type === 'map') {
+        const oil = _.find(this.$parent.oils, function(oil) {
+          return oil.value === value
+        })
+
+        this.$parent.addOil(oil)
+      } else {
+        this.$parent.combo = this.getAnointmentCombo(value)
       }
     },
     formatDescription: function(anointment) {


### PR DESCRIPTION
Allows users to see the oils required for an anointment without having to add it to the simulator. Oil combos are now set when the data is initialized instead of calculating the combo whenever it is selected.

Resolves #1 